### PR TITLE
Make /usr/bin/mupprnt executable when using simple.makefile

### DIFF
--- a/simple.makefile
+++ b/simple.makefile
@@ -327,6 +327,7 @@ install-mupmate:	src/mupmate/mupmate
 
 install-mupprnt: src/mupprnt/mupprnt
 	cp src/mupprnt/mupprnt $(BINDIR)/mupprnt
+	chmod +x $(BINDIR)/mupprnt
 
 install-mupdocs: LICENSE doc/uguide.ps doc/quickref.ps \
 	doc/manpages/mup.ps doc/manpages/mupmate.ps \


### PR DESCRIPTION
The mupprnt script is packaged in the tar file with non-executable permission
bits, so when it's copied to /usr/bin by using the simple.makefile, it lacks
executable permissions.  This flags warnings in Fedora package linters.

Using the ./configure; make; make install flow appears to install this script
with the proper executable bits.